### PR TITLE
change variable name to reflect service

### DIFF
--- a/server.js
+++ b/server.js
@@ -5,13 +5,13 @@ const LanguageTranslatorV3 = require('ibm-watson/language-translator/v3');
 
 const PORT = 8080;
 const HOST = '0.0.0.0';
-const NLP_VERSION = '2018-05-01';
-const NLP_URL = 'https://gateway.watsonplatform.net/language-translator/api';
+const LT_VERSION = '2018-05-01';
+const LT_URL = 'https://gateway.watsonplatform.net/language-translator/api';
 
 const languageTranslator = new LanguageTranslatorV3({
-  version: NLP_VERSION,
+  version: LT_VERSION,
   iam_apikey: process.env.nlp_key,
-  url: NLP_URL,
+  url: LT_URL,
 });
 
 const app = express();


### PR DESCRIPTION
we're not using Watson's NLP service, call the variables LT instead.